### PR TITLE
Be more tolerant of dev workstation environment

### DIFF
--- a/src/managed/PostBuild.CreateInstaller/createinstaller.cmd
+++ b/src/managed/PostBuild.CreateInstaller/createinstaller.cmd
@@ -9,10 +9,17 @@ IF "%OLW_CONFIG%" == "" (
   set OLW_CONFIG=Debug
 )
 
-%LocalAppData%\Nuget\Nuget.exe pack .\OpenLiveWriter.nuspec -version %dottedVersion% -basepath src\managed\bin\%OLW_CONFIG%\i386\Writer
+IF EXIST "%LocalAppData%\Nuget\Nuget.exe" (GOTO package) ELSE (
+   echo Nuget.exe missing from %LocalAppData%\Nuget\Nuget.exe
+   GOTO end
+)
+
+:package
+"%LocalAppData%\Nuget\Nuget.exe" pack .\OpenLiveWriter.nuspec -version %dottedVersion% -basepath src\managed\bin\%OLW_CONFIG%\i386\Writer
 ECHO Created Writer NuGet package.
 
 .\src\managed\packages\squirrel.windows.1.2.1\tools\Squirrel.exe -i .\src\managed\OpenLiveWriter.PostEditor\Images\Writer.ico %OLW_SIGN% --no-msi --releasify .\OpenLiveWriter.%dottedVersion%.nupkg 
 ECHO Created Open Live Writer setup file.
 
+:end
 POPD


### PR DESCRIPTION
Fix postinstaller to be more tolerant: (i) Use quote marks to ensure spaces in the user profile directory (e.g. C:\Users\Tim Sneath) don't break the batch file; (ii) fail more gently if Nuget.exe isn't in the %localappdata% directory, since it's not installed by default with Visual Studio.
